### PR TITLE
Analytics2views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ◷ **HOUR TRACKER** — one file. no server. no fuss.
 
-**beta-1.2.0**
+**beta-1.2.1**
 
 A minimal, offline-first hour tracker that lives in your browser. No login, no server, no complications.
 
@@ -105,8 +105,14 @@ Data stored locally: your task list, colors, hours per day, daily cap, and last 
 
 ---
 
-## Recent Updates (beta-1.2.0)
+## Recent Updates
 
+**beta-1.2.1** — Bug fixes
+- Color Picker: Fixed visual glitch where picker state switched across all tasks (Issue #8)
+- Back Navigation: Changed from folder link to history.back() for clean navigation (Issue #9)
+- Dark Mode Flash: Added synchronous dark mode check in page head to prevent light mode flash on navigation
+
+**beta-1.2.0** — Delivery tracking, charts, full-year heatmap
 - Burn Chart: Refined visualization with ideal trajectory line
 - Date Formatting: Consistent display + "Month Day Year" in requirements
 - Hours Done Views: Toggle between Week (W14) and Day (Apr 1) with tooltips

--- a/analytics.html
+++ b/analytics.html
@@ -266,10 +266,10 @@
   <div class="min-h-screen flex flex-col">
     <!-- Header -->
     <header class="fixed top-0 left-0 right-0 flex items-center justify-between px-4 md:px-8 py-3 md:py-4 bg-card/80 dark:bg-card-dark/80 backdrop-blur-sm border-b border-gray-200 dark:border-white/5 z-30 transition-colors duration-300">
-      <a href="./" aria-label="Back to home" class="flex items-center gap-2 hover:opacity-80 transition-opacity">
+      <button onclick="window.history.back()" aria-label="Back to home" class="flex items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer bg-transparent border-none p-0">
         <img src="./icons/back-arrow.svg" alt="" class="w-6 h-6 text-gray-900 dark:text-white forced-color-adjust-none md:forced-color-adjust-auto" aria-hidden="true">
         <h1 class="text-lg md:text-xl font-bold tracking-tight text-gray-900 dark:text-white">Analytics</h1>
-      </a>
+      </button>
       <div class="relative">
         <button id="appMenuBtn" aria-label="App menu" class="flex items-center gap-2 hover:opacity-80 transition-opacity">
           <img src="./icons/menu-dots.svg" alt="" class="w-4 h-4 text-gray-600 dark:text-gray-400 forced-color-adjust-none md:forced-color-adjust-auto" aria-hidden="true">

--- a/analytics.html
+++ b/analytics.html
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light dark">
   <title>Analytics - Hour Tracker</title>
+  <script>
+    if (localStorage.getItem('dt_darkMode') !== 'false') {
+      document.documentElement.classList.add('dark');
+      document.documentElement.style.colorScheme = 'dark';
+    }
+  </script>
   <style>
     html { background-color: #f5f5f5; }
     html.dark { background-color: #1a1a2e; }

--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
   <meta name="color-scheme" content="light dark">
   <title>Hour Tracker</title>
   <!-- Beta-1.0.1 -->
+  <script>
+    if (localStorage.getItem('dt_darkMode') !== 'false') {
+      document.documentElement.classList.add('dark');
+      document.documentElement.style.colorScheme = 'dark';
+    }
+  </script>
   <style>
     html { background-color: #f5f5f5; }
     html.dark { background-color: #1a1a2e; }

--- a/settings-modal.js
+++ b/settings-modal.js
@@ -519,17 +519,20 @@ window._settingsModalUpdateTaskColor = (i, c) => {
     tasks[i].color = c;
     SettingsModal.config.onSave?.();
 
-    // Update only the color swatch active state, don't re-render
-    const allSwatches = document.querySelectorAll('button.color-swatch');
-    allSwatches.forEach(swatch => {
-      swatch.classList.remove('active');
-    });
-    // Find and activate the clicked color swatch
-    allSwatches.forEach(swatch => {
-      if (swatch.getAttribute('aria-label')?.toLowerCase() === c.toLowerCase()) {
-        swatch.classList.add('active');
-      }
-    });
+    // Update only the color swatch active state for this specific task
+    const taskContainer = document.getElementById(`taskContainer-${i}`);
+    if (taskContainer) {
+      const swatches = taskContainer.querySelectorAll('button.color-swatch');
+      swatches.forEach(swatch => {
+        swatch.classList.remove('active');
+      });
+      // Activate only the clicked color swatch for this task
+      swatches.forEach(swatch => {
+        if (swatch.getAttribute('aria-label')?.toLowerCase() === c.toLowerCase()) {
+          swatch.classList.add('active');
+        }
+      });
+    }
 
     if (!SettingsModal.state.isAddTaskMode) {
       SettingsModal.config.onTasksChanged?.();


### PR DESCRIPTION
# Beta-1.2.1: Bug fixes — color picker, back navigation, dark mode flash

## Summary

This patch fixes three UI bugs discovered during beta-1.2.0 testing: a visual glitch in the color picker, unsafe back button navigation exposing folder paths, and a light mode flash when returning to dark mode pages.

## Bugs Fixed

### Issue #8: Color Picker Visual Glitch
- **Problem:** When selecting a new color for a task, the active state indicator switched across all task rows instead of just the selected task
- **Root cause:** DOM query selected all color swatches globally instead of scoping to the current task
- **Fix:** Changed `document.querySelectorAll()` to `taskContainer.querySelectorAll()` in `_settingsModalUpdateTaskColor()`
- **Impact:** Visual feedback only — data was always saved correctly; this fixes the confusing UI

### Issue #9: Back Button Navigation Exposes Folder
- **Problem:** Back button linked to `href="./"` which exposes the folder path and creates poor UX
- **Fix:** Changed from `<a href="./">` to `<button onclick="window.history.back()">` 
- **Benefits:** 
  - Uses browser history API (respects where user came from)
  - No folder path exposed
  - Cleaner navigation

### Dark Mode Flash on Page Navigation
- **Problem:** When navigating between pages while in dark mode, light mode briefly flashes before dark mode applies
- **Root cause:** Dark mode class applied in JavaScript after page rendering started
- **Fix:** Added synchronous `<script>` in `<head>` that applies `dark` class before any rendering
- **Applied to:** Both `index.html` and `analytics.html`

## Files Changed

- `settings-modal.js` — Fixed color swatch event scoping (lines 516-537)
- `analytics.html` — Changed back button to use history.back() + added dark mode sync script (lines 269 + head)
- `index.html` — Added dark mode sync script in head
- `README.md` — Version bump to beta-1.2.1 + update notes

## Testing Checklist

### Color Picker Fix
- [x] Open Settings
- [x] Task 1 → click "Green" swatch → **only Task 1's green should highlight**
- [x] Task 2 → click "Blue" swatch → **only Task 2's blue should highlight (Task 1 stays green)**
- [x] Task 1 → click "Red" → **Task 1 switches to red, Task 2 stays blue**
- [x] Verify data saved correctly (all colors persist on page reload)

### Back Button Navigation
- [x] Open index.html (light mode)
- [x] Click Analytics link → goes to analytics.html
- [x] Click back button → returns to index.html
- [x] Verify URL bar shows clean path (no folder exposure)
- [x] Test on mobile (responsive back button should work)
- [x] Test on desktop with different referrers (should go back correctly)

### Dark Mode Flash Prevention
- [x] **Light mode user:** Enable dark mode in Settings → refresh page → **no white flash**
- [x] **Dark mode user:** Navigate from index.html → Analytics → **no flash**
- [x] **Dark mode user:** Navigate from Analytics → back to index.html → **no flash**
- [x] **Hard refresh** (Cmd+Shift+R / Ctrl+Shift+R) → page loads in dark mode immediately, no flash
- [x] Test on mobile Safari, Chrome, Firefox → no flashing
- [x] Switch dark mode off → navigate to different page → no dark flash

### General
- [x] Load main branch data in Analytics2views — verify nothing broke
- [x] Task colors still display correctly everywhere
- [x] Settings modal renders cleanly
- [ ] No console errors
- [x] Dark mode toggle still works as expected

## Version Info

- **Previous:** beta-1.2.0
- **Current:** beta-1.2.1
- **Type:** Patch release (bug fixes only, no new features)
- **Breaking changes:** None


