### PR TITLE
Optimization 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HOUR TRACKER
 one file. no server. no fuss.
 
-**v1.4.1-beta2**
+**v1.4.2-beta2**
 
 A minimal, offline-first hour tracker that lives in your browser. No login, no server, no complications.
 
@@ -43,8 +43,11 @@ How it fills:
 - Monthly grid with daily hour breakdown
 - Visual 4-square stacking (2h per square)
 - Red highlight when you exceed your daily cap
+- Month title shows count of filled days for the month
 - Click any day to log hours
-- Click task legend → navigate to by-task analytics
+- Day sheet supports keyboard entry: type hours and move between tasks without touching the mouse
+- Status pill shown per task in the day sheet (Soon, In Pause, In Progress, etc.)
+- Click task legend → navigate to by-task analytics for the month you're viewing
 - Click month label → jump to analytics overview for that month
 
 **Analytics**
@@ -63,7 +66,9 @@ How it fills:
 - Decimal hours supported (1.5, 0.25, etc.)
 - Color-coded tasks
 - Optional Jira links
-- Delivery date tracking with overdue warnings
+- Delivery date tracking with overdue warnings (shows "Today" on the due date itself)
+- Status: Soon, In Pause, In Progress, Dev started, Final review, Done, Archived
+- Tasks marked Done, Dev started, or Archived are hidden from the day sheet automatically
 - Month navigation built in
 
 **Other**
@@ -107,11 +112,21 @@ Everything stays in your browser's localStorage. Nothing is sent anywhere.
 Data stored locally: your task list, colors, hours per day, daily cap, and last entry timestamp.
 
 **Export:** DevTools → Application → Local Storage → copy values
-**Reset:** Settings → Delete all data
+**Reset:** Archive → App menu → Delete all data
 
 ---
 
 ## Recent Updates
+
+**v1.4.2-beta2** — Keyboard entry, status overhaul, navigation & tracking fixes
+- Day Sheet: keyboard hour entry and task selection — type hours and move between tasks without the mouse
+- Home Calendar: month title now shows a count of filled days for the month
+- Task Status: added "Dev started"; renamed "Checking" to "Final review"; Done/Dev started tasks now hidden from the day sheet alongside Archived; status pill added to each day-sheet row; status list reordered (Soon, In Pause, In Progress, Dev started, Final review, Done, Archived)
+- Delivery Date Badge: shows "Today" instead of "Delivery date passed" when the delivery date is the current day
+- Overview Task Legend: fixed an index mismatch that could silently drop tasks with logged hours from the legend
+- Scope Change Tracking: estimate reductions are now recorded too (not just increases), with a correctly signed "-Xd" label on the burn chart
+- Task Legend Navigation: clicking a task from the day-tracker's legend now opens its by-task analytics scoped to the month you were viewing, instead of resetting to the default month
+- Delete All Data: moved from the Settings panel to the Archive page's app menu
 
 **v1.4.1-beta2** — Burndown refinements, navigation improvements, momentum analytics
 - Weekly Breakdown: add group display for same ID and adjust to facilitate copy to excel the day value

--- a/analytics.html
+++ b/analytics.html
@@ -1304,7 +1304,8 @@
 
             // Label showing days added (to the left of the diamond)
             const daysAdded = change.to - change.from;
-            const labelText = `+${daysAdded.toFixed(1)}d`;
+            const sign = daysAdded >= 0 ? '+' : '';
+            const labelText = `${sign}${daysAdded.toFixed(1)}d`;
             ctx.fillStyle = 'rgba(245, 158, 11, 0.9)';
             ctx.font = '11px sans-serif';
             ctx.textAlign = 'right';

--- a/analytics.html
+++ b/analytics.html
@@ -3237,9 +3237,20 @@
     }
 
 
+    function calcFilledDaysInMonth(year, month) {
+      const daysInMonth = new Date(year, month + 1, 0).getDate();
+      let count = 0;
+      for (let d = 1; d <= daysInMonth; d++) {
+        const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+        if (getTotalHours(dateStr) > 0) count++;
+      }
+      return count;
+    }
+
     function updateMonthLabel() {
       const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
-      const label = `${monthNames[linearViewMonth]} ${linearViewYear}`;
+      const filledDays = calcFilledDaysInMonth(linearViewYear, linearViewMonth);
+      const label = `${monthNames[linearViewMonth]} ${linearViewYear} (${filledDays})`;
       const monthLabelEl = document.getElementById('monthLabel');
       monthLabelEl.textContent = label;
 

--- a/analytics.html
+++ b/analytics.html
@@ -2406,8 +2406,11 @@
       // Set the status badge in the header using task status if available
       const badgeEl = document.getElementById('bytaskProgressBadge');
       if (badgeEl) {
-        const deliveryPassed = deliveryDate && getWorkingDaysTo(deliveryDate) === 0;
-        const deliveryBadge = deliveryPassed
+        const deliveryToday = deliveryDate === todayStr();
+        const deliveryPassed = deliveryDate && !deliveryToday && getWorkingDaysTo(deliveryDate) === 0;
+        const deliveryBadge = deliveryToday
+          ? `<span class="inline-flex items-center gap-1.5 text-xs bg-amber-500/20 text-amber-600 dark:text-amber-400 px-2.5 py-1 rounded-full font-medium">Today</span>`
+          : deliveryPassed
           ? `<span class="inline-flex items-center gap-1.5 text-xs bg-red-500/20 text-red-600 dark:text-red-400 px-2.5 py-1 rounded-full font-medium">Delivery date passed</span>`
           : '';
         badgeEl.innerHTML = `${deliveryBadge}<span class="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full font-medium ${taskStatusColor}">${taskStatusDisplay}</span>`;

--- a/analytics.html
+++ b/analytics.html
@@ -2387,14 +2387,16 @@
       const statusMap = {
         'soon': 'Soon',
         'inProgress': 'In Progress',
+        'devStarted': 'Dev started',
         'inPause': 'In Pause',
         'done': 'Done',
-        'checking': 'Checking',
+        'checking': 'Final review',
         'archived': 'Archived'
       };
       const statusColorMap = {
         'soon': 'bg-gray-500/20 text-gray-600 dark:text-gray-300',
         'inProgress': 'bg-yellow-500/20 text-yellow-600 dark:text-yellow-400',
+        'devStarted': 'bg-indigo-500/20 text-indigo-600 dark:text-indigo-400',
         'inPause': 'bg-orange-500/20 text-orange-600 dark:text-orange-400',
         'done': 'bg-green-500/20 text-green-600 dark:text-green-400',
         'checking': 'bg-blue-500/20 text-blue-600 dark:text-blue-400',

--- a/analytics.html
+++ b/analytics.html
@@ -2005,6 +2005,7 @@
         todayStr,
         COLOR_HEX,
         fmtH,
+        getTaskIndex: (t) => tasks.indexOf(t),
       };
 
       LegendRenderer.render('overviewTaskLegend', options);

--- a/archive.html
+++ b/archive.html
@@ -133,9 +133,10 @@
       const statusMap = {
         'soon': 'Soon',
         'inProgress': 'In Progress',
+        'devStarted': 'Dev started',
         'inPause': 'In Pause',
         'done': 'Done',
-        'checking': 'Checking',
+        'checking': 'Final review',
         'archived': 'Archived'
       };
       return statusMap[status] || '—';
@@ -242,9 +243,10 @@
               <option value="" ${task.status === '' ? 'selected' : ''}>—</option>
               <option value="soon" ${task.status === 'soon' ? 'selected' : ''}>Soon</option>
               <option value="inProgress" ${task.status === 'inProgress' ? 'selected' : ''}>In Progress</option>
+              <option value="devStarted" ${task.status === 'devStarted' ? 'selected' : ''}>Dev started</option>
               <option value="inPause" ${task.status === 'inPause' ? 'selected' : ''}>In Pause</option>
               <option value="done" ${task.status === 'done' ? 'selected' : ''}>Done</option>
-              <option value="checking" ${task.status === 'checking' ? 'selected' : ''}>Checking</option>
+              <option value="checking" ${task.status === 'checking' ? 'selected' : ''}>Final review</option>
               <option value="archived" ${task.status === 'archived' ? 'selected' : ''}>Archived</option>
             </select>
           </td>`;

--- a/archive.html
+++ b/archive.html
@@ -70,6 +70,9 @@
             <span id="dropdownDarkModeKnob" class="absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform duration-200 translate-x-4"></span>
           </button>
         </div>
+        <button id="deleteAllDataLink" class="w-full text-left px-4 py-2 text-sm text-red-500 hover:bg-black/5 dark:hover:bg-white/5 transition-colors">
+          Delete all data
+        </button>
       </div>
     </div>
   </header>
@@ -132,11 +135,11 @@
     function formatStatusDisplay(status) {
       const statusMap = {
         'soon': 'Soon',
+        'inPause': 'In Pause',
         'inProgress': 'In Progress',
         'devStarted': 'Dev started',
-        'inPause': 'In Pause',
-        'done': 'Done',
         'checking': 'Final review',
+        'done': 'Done',
         'archived': 'Archived'
       };
       return statusMap[status] || '—';
@@ -242,11 +245,11 @@
               onchange="updateActiveField(this.value); commitEdit();">
               <option value="" ${task.status === '' ? 'selected' : ''}>—</option>
               <option value="soon" ${task.status === 'soon' ? 'selected' : ''}>Soon</option>
+              <option value="inPause" ${task.status === 'inPause' ? 'selected' : ''}>In Pause</option>
               <option value="inProgress" ${task.status === 'inProgress' ? 'selected' : ''}>In Progress</option>
               <option value="devStarted" ${task.status === 'devStarted' ? 'selected' : ''}>Dev started</option>
-              <option value="inPause" ${task.status === 'inPause' ? 'selected' : ''}>In Pause</option>
-              <option value="done" ${task.status === 'done' ? 'selected' : ''}>Done</option>
               <option value="checking" ${task.status === 'checking' ? 'selected' : ''}>Final review</option>
+              <option value="done" ${task.status === 'done' ? 'selected' : ''}>Done</option>
               <option value="archived" ${task.status === 'archived' ? 'selected' : ''}>Archived</option>
             </select>
           </td>`;
@@ -361,6 +364,22 @@
     });
 
     document.getElementById('dropdownDarkMode')?.addEventListener('click', toggleDarkMode);
+
+    // Delete all data (confirmation dialog provided by SettingsModal)
+    SettingsModal.init({
+      getTasks: () => tasks,
+      setTasks: (t) => { tasks = t; },
+      getCompletions: () => JSON.parse(localStorage.getItem('dt_completions') || '{}'),
+      setCompletions: (c) => localStorage.setItem('dt_completions', JSON.stringify(c)),
+      getMaxCap: () => parseFloat(localStorage.getItem('dt_maxCap')) || 7.5,
+      setMaxCap: (v) => localStorage.setItem('dt_maxCap', v),
+      onSave: saveTasks,
+      onReload: () => location.reload(),
+    });
+    document.getElementById('deleteAllDataLink')?.addEventListener('click', () => {
+      document.getElementById('appMenu')?.classList.add('hidden');
+      SettingsModal.openDeleteAllModal();
+    });
 
     // Initial load
     loadTasks();

--- a/index.html
+++ b/index.html
@@ -919,7 +919,7 @@
       }
 
       el.innerHTML = tasks.map((t, i) => {
-        if (t && t.status === 'archived') return '';
+        if (t && (t.status === 'archived' || t.status === 'done' || t.status === 'devStarted')) return '';
         const isSelected = selectedTaskIndex === i;
         return `
         <div class="flex items-center gap-3 p-3 md:p-4 rounded-xl bg-black/5 dark:bg-white/5 cursor-pointer transition-shadow ${isSelected ? 'ring-2 ring-gray-400 dark:ring-white/40' : ''}" onclick="selectTaskRow(event, ${i})">

--- a/index.html
+++ b/index.html
@@ -735,12 +735,25 @@
       });
     }
 
+    // ── Count days with logged hours in viewed month ──────
+    function calcFilledDays() {
+      const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+      let count = 0;
+      for (let d = 1; d <= daysInMonth; d++) {
+        const ds = `${viewYear}-${String(viewMonth + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+        const total = getCompletions(ds).reduce((a, b) => a + b, 0);
+        if (total > 0) count++;
+      }
+      return count;
+    }
+
     // ── Render Month Navigation ───────────────────────────
     function renderMonthNav() {
       const d = new Date(viewYear, viewMonth, 1);
       const label = d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+      const filledDays = calcFilledDays();
       const monthLabelEl = document.getElementById('monthLabel');
-      monthLabelEl.textContent = label;
+      monthLabelEl.textContent = `${label} (${filledDays})`;
 
       const tooltipEl = document.getElementById('monthTooltip');
       tooltipEl.textContent = 'go to analytics';

--- a/index.html
+++ b/index.html
@@ -731,8 +731,8 @@
         COLOR_HEX,
         fmtH,
         onTaskClick: (taskIndex) => {
-          // Navigate to analytics.html in by-task view for this task
-          window.location.href = `./analytics.html?view=bytask&task=${taskIndex}`;
+          // Navigate to analytics.html in by-task view for this task, preserving the viewed month
+          window.location.href = `./analytics.html?view=bytask&task=${taskIndex}&month=${viewMonth}&year=${viewYear}`;
         },
       });
     }

--- a/index.html
+++ b/index.html
@@ -340,6 +340,8 @@
     let burnoutToastTimer = null;  // its dismiss timer
     let burnoutShown      = false; // has it been shown this day session?
     let lastFillToastEl       = null;  // reference to the live last-fill toast DOM node
+    let pendingHourFocusIndex = null;  // task index the user is mousing down into, to restore focus after the blur-triggered re-render destroys the node
+    let selectedTaskIndex = null;      // task row selected (by click) as the target for arrow-key hour adjustments
 
     // ── Dark mode ────────────────────────────────────────
     let darkMode = localStorage.getItem('dt_darkMode') !== 'false'; // default: dark
@@ -884,6 +886,7 @@
     // ── Deselect (close sheet) ────────────────────────────
     function deselectDay() {
       selectedDate = null;
+      selectedTaskIndex = null;
       closeSheet();
       renderCalendar();
     }
@@ -917,12 +920,13 @@
 
       el.innerHTML = tasks.map((t, i) => {
         if (t && t.status === 'archived') return '';
+        const isSelected = selectedTaskIndex === i;
         return `
-        <div class="flex items-center gap-3 p-3 md:p-4 rounded-xl bg-black/5 dark:bg-white/5">
+        <div class="flex items-center gap-3 p-3 md:p-4 rounded-xl bg-black/5 dark:bg-white/5 cursor-pointer transition-shadow ${isSelected ? 'ring-2 ring-gray-400 dark:ring-white/40' : ''}" onclick="selectTaskRow(event, ${i})">
           <div class="w-3 h-3 rounded-full shrink-0" style="background:${COLOR_HEX[t.color]}"></div>
-          ${t.jiraLink ? `<a href="${t.jiraLink}" target="_blank" rel="noopener noreferrer" class="flex-1 text-sm md:text-base font-medium text-gray-900 dark:text-white/90 hover:underline">${t.name}</a>` : `<span class="flex-1 text-sm md:text-base font-medium text-gray-900 dark:text-white/90">${t.name}</span>`}
+          ${t.jiraLink ? `<a href="${t.jiraLink}" target="_blank" rel="noopener noreferrer" class="task-name text-sm md:text-base font-medium text-gray-900 dark:text-white/90 hover:underline">${t.name}</a>` : `<span class="task-name text-sm md:text-base font-medium text-gray-900 dark:text-white/90">${t.name}</span>`}
           <input type="number" min="0" step="0.25" value="${comp[i] || 0}" data-task-index="${i}"
-            class="w-20 bg-black/5 dark:bg-white/10 border border-gray-200 dark:border-white/10 rounded-lg px-2 py-1.5 text-sm text-right text-gray-900 dark:text-white focus:outline-none focus:border-gray-400 dark:focus:border-white/30 transition-colors"
+            class="w-20 ml-auto bg-black/5 dark:bg-white/10 border border-gray-200 dark:border-white/10 rounded-lg px-2 py-1.5 text-sm text-right text-gray-900 dark:text-white focus:outline-none focus:border-gray-400 dark:focus:border-white/30 transition-colors"
             onchange="updateHours(${i}, this.value)" onblur="updateHours(${i}, this.value)" onkeydown="handleHourKeydown(event, ${i})">
           <span class="text-xs text-gray-400 dark:text-white/40 w-3">h</span>
         </div>
@@ -961,23 +965,58 @@
       }
       renderTaskList();
       renderCalendar();
+      if (pendingHourFocusIndex !== null) {
+        const target = document.querySelector(`input[data-task-index="${pendingHourFocusIndex}"]`);
+        pendingHourFocusIndex = null;
+        if (target) { target.focus(); target.select(); }
+      }
     }
-    function handleHourKeydown(e, index) {
-      let delta = 0;
-      if (e.key === 'ArrowUp') delta = 0.25;
-      else if (e.key === 'ArrowDown') delta = -0.25;
-      else if (e.key === 'ArrowRight') delta = 1;
-      else if (e.key === 'ArrowLeft') delta = -1;
-      else return;
-      e.preventDefault();
-      const current = parseFloat(e.target.value) || 0;
+    function arrowKeyDelta(key) {
+      if (key === 'ArrowUp') return 0.25;
+      if (key === 'ArrowDown') return -0.25;
+      if (key === 'ArrowRight') return 1;
+      if (key === 'ArrowLeft') return -1;
+      return null;
+    }
+    function applyHourDelta(index, delta) {
+      if (!selectedDate) return;
+      const comp = getCompletions(selectedDate);
+      const current = comp[index] || 0;
       const next = Math.max(0, Math.round((current + delta) * 100) / 100);
       updateHours(index, next);
+    }
+    function handleHourKeydown(e, index) {
+      const delta = arrowKeyDelta(e.key);
+      if (delta === null) return;
+      e.preventDefault();
+      applyHourDelta(index, delta);
       const newInput = document.querySelector(`input[data-task-index="${index}"]`);
       if (newInput) {
         newInput.focus();
         newInput.select();
       }
+    }
+    // Toggle the ring highlight on rows without rebuilding their DOM nodes —
+    // a full renderTaskList() here would destroy a focused input mid-click.
+    function setSelectedTask(index) {
+      selectedTaskIndex = index;
+      document.querySelectorAll('#taskList input[data-task-index]').forEach((input) => {
+        const row = input.closest('div');
+        const isSelected = index !== null && Number(input.dataset.taskIndex) === index;
+        row.classList.toggle('ring-2', isSelected);
+        row.classList.toggle('ring-gray-400', isSelected);
+        row.classList.toggle('dark:ring-white/40', isSelected);
+      });
+    }
+    function selectTaskRow(e, index) {
+      if (e.target.closest('.task-name')) return;
+      if (e.target.tagName === 'INPUT') {
+        // Clicking directly into the field: keep selection in sync so arrow
+        // keys still target it after the user clicks elsewhere afterward.
+        setSelectedTask(index);
+        return;
+      }
+      setSelectedTask(selectedTaskIndex === index ? null : index);
     }
 
     // ── Month Summary ─────────────────────────────────────
@@ -1188,6 +1227,16 @@
 
     document.getElementById('bottomSheet').addEventListener('click', (e) => {
       e.stopPropagation();
+    });
+
+    // mousedown fires before the outgoing input's blur (which rebuilds the list
+    // and would otherwise destroy the node the click was about to focus). Any
+    // mousedown outside #taskList (day cell, close button, nav...) must clear
+    // this immediately, or a stale index gets consumed while switching days
+    // and forces focus back onto the day you're leaving.
+    document.addEventListener('mousedown', (e) => {
+      const input = e.target.closest('#taskList input[data-task-index]');
+      pendingHourFocusIndex = input ? input.dataset.taskIndex : null;
     });
 
     // ── Month Navigation ──────────────────────────────────
@@ -1403,16 +1452,28 @@
         return;
       }
       if (inInput || settingsOpen) return;
+      if (sheetOpen) {
+        // Arrow keys are dedicated to adjusting the selected task's hours
+        // while the sheet is open, not to month/day navigation.
+        if (selectedTaskIndex !== null) {
+          const delta = arrowKeyDelta(e.key);
+          if (delta !== null) {
+            e.preventDefault();
+            applyHourDelta(selectedTaskIndex, delta);
+          }
+        }
+        return;
+      }
       if (e.key === 'ArrowLeft')  { e.preventDefault(); navigateDay(-1); return; }
       if (e.key === 'ArrowRight') { e.preventDefault(); navigateDay(1);  return; }
       if (e.key === 'ArrowUp') {
         e.preventDefault();
-        if (canGoPrev()) { viewMonth--; if (viewMonth < 0) { viewMonth = 11; viewYear--; } if (sheetOpen) deselectDay(); renderCalendar(); }
+        if (canGoPrev()) { viewMonth--; if (viewMonth < 0) { viewMonth = 11; viewYear--; } renderCalendar(); }
         return;
       }
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        if (canGoNext()) { viewMonth++; if (viewMonth > 11) { viewMonth = 0; viewYear++; } if (sheetOpen) deselectDay(); renderCalendar(); }
+        if (canGoNext()) { viewMonth++; if (viewMonth > 11) { viewMonth = 0; viewYear++; } renderCalendar(); }
         return;
       }
     });

--- a/index.html
+++ b/index.html
@@ -918,13 +918,31 @@
         }
       }
 
+      const statusLabels = {
+        soon: 'Soon', inProgress: 'In Progress', devStarted: 'Dev started',
+        inPause: 'In Pause', done: 'Done', checking: 'Final review', archived: 'Archived'
+      };
+      const statusColors = {
+        soon: 'bg-gray-500/20 text-gray-600 dark:text-gray-300',
+        inProgress: 'bg-yellow-500/20 text-yellow-600 dark:text-yellow-400',
+        devStarted: 'bg-indigo-500/20 text-indigo-600 dark:text-indigo-400',
+        inPause: 'bg-orange-500/20 text-orange-600 dark:text-orange-400',
+        done: 'bg-green-500/20 text-green-600 dark:text-green-400',
+        checking: 'bg-blue-500/20 text-blue-600 dark:text-blue-400',
+        archived: 'bg-gray-500/20 text-gray-600 dark:text-gray-300'
+      };
+
       el.innerHTML = tasks.map((t, i) => {
         if (t && (t.status === 'archived' || t.status === 'done' || t.status === 'devStarted')) return '';
         const isSelected = selectedTaskIndex === i;
+        const statusPill = t.status
+          ? `<span class="text-[10px] md:text-xs px-2 py-0.5 rounded-full font-medium shrink-0 ${statusColors[t.status] || statusColors.soon}">${statusLabels[t.status] || t.status}</span>`
+          : '';
         return `
         <div class="flex items-center gap-3 p-3 md:p-4 rounded-xl bg-black/5 dark:bg-white/5 cursor-pointer transition-shadow ${isSelected ? 'ring-2 ring-gray-400 dark:ring-white/40' : ''}" onclick="selectTaskRow(event, ${i})">
           <div class="w-3 h-3 rounded-full shrink-0" style="background:${COLOR_HEX[t.color]}"></div>
           ${t.jiraLink ? `<a href="${t.jiraLink}" target="_blank" rel="noopener noreferrer" class="task-name text-sm md:text-base font-medium text-gray-900 dark:text-white/90 hover:underline">${t.name}</a>` : `<span class="task-name text-sm md:text-base font-medium text-gray-900 dark:text-white/90">${t.name}</span>`}
+          ${statusPill}
           <input type="number" min="0" step="0.25" value="${comp[i] || 0}" data-task-index="${i}"
             class="w-20 ml-auto bg-black/5 dark:bg-white/10 border border-gray-200 dark:border-white/10 rounded-lg px-2 py-1.5 text-sm text-right text-gray-900 dark:text-white focus:outline-none focus:border-gray-400 dark:focus:border-white/30 transition-colors"
             onchange="updateHours(${i}, this.value)" onblur="updateHours(${i}, this.value)" onkeydown="handleHourKeydown(event, ${i})">

--- a/index.html
+++ b/index.html
@@ -921,9 +921,9 @@
         <div class="flex items-center gap-3 p-3 md:p-4 rounded-xl bg-black/5 dark:bg-white/5">
           <div class="w-3 h-3 rounded-full shrink-0" style="background:${COLOR_HEX[t.color]}"></div>
           ${t.jiraLink ? `<a href="${t.jiraLink}" target="_blank" rel="noopener noreferrer" class="flex-1 text-sm md:text-base font-medium text-gray-900 dark:text-white/90 hover:underline">${t.name}</a>` : `<span class="flex-1 text-sm md:text-base font-medium text-gray-900 dark:text-white/90">${t.name}</span>`}
-          <input type="number" min="0" step="0.25" value="${comp[i] || 0}"
+          <input type="number" min="0" step="0.25" value="${comp[i] || 0}" data-task-index="${i}"
             class="w-20 bg-black/5 dark:bg-white/10 border border-gray-200 dark:border-white/10 rounded-lg px-2 py-1.5 text-sm text-right text-gray-900 dark:text-white focus:outline-none focus:border-gray-400 dark:focus:border-white/30 transition-colors"
-            onchange="updateHours(${i}, this.value)" onblur="updateHours(${i}, this.value)">
+            onchange="updateHours(${i}, this.value)" onblur="updateHours(${i}, this.value)" onkeydown="handleHourKeydown(event, ${i})">
           <span class="text-xs text-gray-400 dark:text-white/40 w-3">h</span>
         </div>
       `;
@@ -961,6 +961,23 @@
       }
       renderTaskList();
       renderCalendar();
+    }
+    function handleHourKeydown(e, index) {
+      let delta = 0;
+      if (e.key === 'ArrowUp') delta = 0.25;
+      else if (e.key === 'ArrowDown') delta = -0.25;
+      else if (e.key === 'ArrowRight') delta = 1;
+      else if (e.key === 'ArrowLeft') delta = -1;
+      else return;
+      e.preventDefault();
+      const current = parseFloat(e.target.value) || 0;
+      const next = Math.max(0, Math.round((current + delta) * 100) / 100);
+      updateHours(index, next);
+      const newInput = document.querySelector(`input[data-task-index="${index}"]`);
+      if (newInput) {
+        newInput.focus();
+        newInput.select();
+      }
     }
 
     // ── Month Summary ─────────────────────────────────────

--- a/legend-renderer.js
+++ b/legend-renderer.js
@@ -12,6 +12,7 @@ const LegendRenderer = {
       COLOR_HEX,
       fmtH,
       onTaskClick,
+      getTaskIndex,
     } = options;
 
     const el = document.getElementById(elementId);
@@ -21,7 +22,8 @@ const LegendRenderer = {
     const todayS = todayStr();
 
     el.innerHTML = tasks
-      .map((t, i) => {
+      .map((t, pos) => {
+        const i = getTaskIndex ? getTaskIndex(t) : pos;
         let total = 0;
         for (let d = 1; d <= daysInMonth; d++) {
           const ds = `${viewYear}-${String(viewMonth + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;

--- a/settings-modal.js
+++ b/settings-modal.js
@@ -311,9 +311,10 @@ const SettingsModal = {
                 <option value="" ${!t.status ? 'selected' : ''}>—</option>
                 <option value="soon" ${t.status === 'soon' ? 'selected' : ''}>Soon</option>
                 <option value="inProgress" ${t.status === 'inProgress' ? 'selected' : ''}>In Progress</option>
+                <option value="devStarted" ${t.status === 'devStarted' ? 'selected' : ''}>Dev started</option>
                 <option value="inPause" ${t.status === 'inPause' ? 'selected' : ''}>In Pause</option>
                 <option value="done" ${t.status === 'done' ? 'selected' : ''}>Done</option>
-                <option value="checking" ${t.status === 'checking' ? 'selected' : ''}>Checking</option>
+                <option value="checking" ${t.status === 'checking' ? 'selected' : ''}>Final review</option>
                 <option value="archived" ${t.status === 'archived' ? 'selected' : ''}>Archived</option>
               </select>
             </div>
@@ -590,9 +591,10 @@ const SettingsModal = {
               <option value="" selected>—</option>
               <option value="soon">Soon</option>
               <option value="inProgress">In Progress</option>
+              <option value="devStarted">Dev started</option>
               <option value="inPause">In Pause</option>
               <option value="done">Done</option>
-              <option value="checking">Checking</option>
+              <option value="checking">Final review</option>
               <option value="archived">Archived</option>
             </select>
           </div>

--- a/settings-modal.js
+++ b/settings-modal.js
@@ -236,7 +236,7 @@ const SettingsModal = {
   },
 
   renderSettings(options = {}) {
-    const { tasks: showTasks = true, dailyCap: showDailyCap = true, deleteData: showDeleteData = true, title = 'Settings' } = options;
+    const { tasks: showTasks = true, dailyCap: showDailyCap = true, deleteData: showDeleteData = false, title = 'Settings' } = options;
     const el = document.getElementById('settingsTasks');
     const titleEl = document.getElementById('settingsTitle');
     if (titleEl) titleEl.textContent = title;
@@ -310,11 +310,11 @@ const SettingsModal = {
                 onchange="window._settingsModalUpdateTaskStatus(${i}, this.value)">
                 <option value="" ${!t.status ? 'selected' : ''}>—</option>
                 <option value="soon" ${t.status === 'soon' ? 'selected' : ''}>Soon</option>
+                <option value="inPause" ${t.status === 'inPause' ? 'selected' : ''}>In Pause</option>
                 <option value="inProgress" ${t.status === 'inProgress' ? 'selected' : ''}>In Progress</option>
                 <option value="devStarted" ${t.status === 'devStarted' ? 'selected' : ''}>Dev started</option>
-                <option value="inPause" ${t.status === 'inPause' ? 'selected' : ''}>In Pause</option>
-                <option value="done" ${t.status === 'done' ? 'selected' : ''}>Done</option>
                 <option value="checking" ${t.status === 'checking' ? 'selected' : ''}>Final review</option>
+                <option value="done" ${t.status === 'done' ? 'selected' : ''}>Done</option>
                 <option value="archived" ${t.status === 'archived' ? 'selected' : ''}>Archived</option>
               </select>
             </div>
@@ -352,6 +352,14 @@ const SettingsModal = {
 
   _showDeleteModal() {
     document.getElementById('deleteModal')?.classList.remove('hidden');
+  },
+
+  // Public entry point for pages that don't show the Settings panel's
+  // delete section (deleteData defaults to false) but still want to
+  // trigger the same confirm-delete flow, e.g. archive.html.
+  openDeleteAllModal() {
+    if (!this.initialized) return;
+    this._showDeleteModal();
   },
 
   _hideDeleteModal() {
@@ -590,11 +598,11 @@ const SettingsModal = {
               onchange="window._settingsModalUpdateTaskStatus(${i}, this.value)">
               <option value="" selected>—</option>
               <option value="soon">Soon</option>
+              <option value="inPause">In Pause</option>
               <option value="inProgress">In Progress</option>
               <option value="devStarted">Dev started</option>
-              <option value="inPause">In Pause</option>
-              <option value="done">Done</option>
               <option value="checking">Final review</option>
+              <option value="done">Done</option>
               <option value="archived">Archived</option>
             </select>
           </div>

--- a/settings-modal.js
+++ b/settings-modal.js
@@ -674,7 +674,7 @@ window._settingsModalFinalizeEstimateChange = (i, v) => {
   const newVal = parseFloat(v) || 0;
   const oldVal = _estimateFocusValue ?? (parseFloat(tasks[i].estimate) || 0);
 
-  if (newVal > oldVal) {
+  if (newVal !== oldVal) {
     const completions = SettingsModal.config.getCompletions?.() || {};
     const hasLoggedHours = Object.values(completions).some(
       comp => Array.isArray(comp) && (comp[i] || 0) > 0


### PR DESCRIPTION
- Version bumped to v1.4.2-beta2 at the top and in a new changelog entry.
- Home Calendar: added month title filled-day count, day-sheet keyboard entry, and status pill.
- Task Tracking: full new status list (Soon → In Pause → In Progress → Dev started → Final review → Done → Archived), and the auto-hide behavior for Done/Dev started/Archived in the day sheet.
- Data & Privacy: "Reset" instructions updated from Settings to Archive → App menu (matching the delete-all move).
- Recent Updates: new v1.4.2-beta2 entry summarizing all 9 commits (keyboard entry, month title count, status overhaul, delivery-date "Today" fix, legend index bug fix, scope-change reduction tracking, month-preserving navigation fix, delete-all relocation).