### PR TITLE
Update README for v1.4.3-beta2 (hold-to-delete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HOUR TRACKER
 one file. no server. no fuss.
 
-**v1.4.2-beta2**
+**v1.4.3-beta2**
 
 A minimal, offline-first hour tracker that lives in your browser. No login, no server, no complications.
 
@@ -117,6 +117,12 @@ Data stored locally: your task list, colors, hours per day, daily cap, and last 
 ---
 
 ## Recent Updates
+
+**v1.4.3-beta2** — Hold-to-confirm deletions
+- Archive Task Deletion: replaced the native browser confirm dialog with the shared custom confirmation modal
+- Hold-to-Delete: both "Delete all data" and per-task delete confirmations now require a 3-second press-and-hold on the delete button instead of a single click, reducing accidental destructive deletes
+- Delete Task Modal: now shows the task name and its total logged hours in the confirmation title (e.g. "Delete Read (3.5h)?")
+- Reusable Confirmation Modal: `SettingsModal.openDeleteTaskModal(name, hours, onConfirm)` lets any page trigger the shared delete-task modal with its own removal logic
 
 **v1.4.2-beta2** — Keyboard entry, status overhaul, navigation & tracking fixes
 - Day Sheet: keyboard hour entry and task selection — type hours and move between tasks without the mouse


### PR DESCRIPTION
Bump README version to v1.4.3-beta2 and add release notes for the new hold-to-confirm deletion UX: replace native confirm with a shared custom modal, require a 3-second press-and-hold for "Delete all data" and per-task deletes, include task name and total logged hours in the delete modal title, and expose SettingsModal.openDeleteTaskModal(name, hours, onConfirm) for reuse.