### PR TITLE
Task change log with vertical timeline

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -503,8 +503,14 @@
             <div class="space-y-2 text-sm"></div>
           </div>
 
-          <!-- Year Heatmap Card (full width) -->
-          <div class="col-span-12 bg-white dark:bg-card-dark rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-white/5">
+          <!-- Change Log Card (col-6 on md+) -->
+          <div id="bytaskLogCard" class="col-span-12 md:col-span-6 bg-white dark:bg-card-dark rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-white/5">
+            <h3 class="font-semibold text-gray-900 dark:text-white mb-4">Change log</h3>
+            <div id="bytaskLogTimeline" class="max-h-96 overflow-y-auto pr-2"></div>
+          </div>
+
+          <!-- Year Heatmap Card (col-6 on md+) -->
+          <div class="col-span-12 md:col-span-6 bg-white dark:bg-card-dark rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-white/5">
             <h3 class="font-semibold text-gray-900 dark:text-white mb-2">Year Heatmap</h3>
             <div id="bytaskHeatmapLegend" class="mb-3"></div>
             <div id="bytaskHeatmapContainer" class="graph-container"></div>
@@ -518,6 +524,7 @@
   <script src="./month-modal.js"></script>
   <script src="./popover.js"></script>
   <script src="./app-menu.js"></script>
+  <script src="./task-log.js"></script>
   <script src="./settings-modal.js"></script>
   <script src="./legend-renderer.js"></script>
   <script>
@@ -1771,6 +1778,60 @@
       }
     }
 
+    function renderTaskLogTimeline(taskIndex) {
+      const el = document.getElementById('bytaskLogTimeline');
+      if (!el) return;
+
+      const task = tasks[taskIndex];
+      if (!task) { el.innerHTML = ''; return; }
+
+      const entries = (window.taskLogGetAll?.() || [])
+        .filter(e => task.uid && e.uid === task.uid)
+        .sort((a, b) => new Date(b.date) - new Date(a.date));
+
+      if (entries.length === 0) {
+        el.innerHTML = `<p style="font-size:14px;color:#6b7280;">No changes recorded yet.</p>`;
+        return;
+      }
+
+      // Note: the vendored Tailwind build is purged to only the classes already
+      // used elsewhere in the app, so this timeline's layout (line, dot, indent,
+      // spacing) is done with inline styles rather than untested utility classes.
+      const isDark = document.documentElement.classList.contains('dark');
+      const lineColor = isDark ? '#2d3751' : '#e5e7eb';
+      const dotColor = lineColor; // dot fill matches the rail, both solid (no opacity)
+      const dotRingColor = isDark ? '#16213e' : '#ffffff'; // ring matches the card background
+      const timeColor = isDark ? 'rgba(255,255,255,0.4)' : '#9ca3af';
+      const titleColor = isDark ? '#ffffff' : '#111827';
+      const descColor = isDark ? '#9ca3af' : '#6b7280';
+
+      const displayValue = (field, value) => {
+        if (field === 'status') return (window.STATUS_LABELS && window.STATUS_LABELS[value]) || '—';
+        return value || '—';
+      };
+
+      // The rail (line) and dots are both positioned relative to the <ol>, at the
+      // same x-coordinate (railX), so the line passes exactly through each dot's
+      // center instead of sitting beside it.
+      const railX = 6; // px from the ol's left edge = dot radius, so dots center on the rail
+      const dotSize = 12;
+      const textIndent = 24; // px from the ol's left edge to where title/text start
+
+      el.innerHTML = `
+        <ol style="position:relative;list-style:none;margin:0;padding:0;">
+          <div style="position:absolute;top:0;bottom:0;left:${railX - 1}px;width:2px;background:${lineColor};"></div>
+          ${entries.map((entry, idx) => `
+            <li style="position:relative;margin-inline-start:${textIndent}px;${idx === entries.length - 1 ? '' : 'margin-bottom:32px;'}">
+              <div style="position:absolute;top:4px;inset-inline-start:${-(textIndent - (railX - dotSize / 2))}px;width:${dotSize}px;height:${dotSize}px;border-radius:9999px;background:${dotColor};border:2px solid ${dotRingColor};"></div>
+              <time style="display:block;margin-bottom:4px;font-size:13px;color:${timeColor};">${new Date(entry.date).toLocaleString()}</time>
+              <h3 style="margin:0;font-size:16px;font-weight:600;color:${titleColor};">${(window.FIELD_LABELS && window.FIELD_LABELS[entry.field]) || entry.field}</h3>
+              <p style="margin:2px 0 0;font-size:14px;color:${descColor};">${displayValue(entry.field, entry.from)} &rarr; ${displayValue(entry.field, entry.to)}</p>
+            </li>
+          `).join('')}
+        </ol>
+      `;
+    }
+
     function renderTaskHeatmap(taskIndex) {
       const el = document.getElementById('bytaskHeatmapContainer');
       const legendEl = document.getElementById('bytaskHeatmapLegend');
@@ -2050,6 +2111,7 @@
       renderTaskDayChart(taskIndex);
       renderTaskAchievements(taskIndex);
       renderTaskHeatmap(taskIndex);
+      renderTaskLogTimeline(taskIndex);
     }
 
     function renderRiskBadge(taskIndex) {

--- a/archive.html
+++ b/archive.html
@@ -100,6 +100,7 @@
   </main>
 
   <!-- Scripts -->
+  <script src="./task-log.js"></script>
   <script src="./settings-modal.js"></script>
 
   <script>
@@ -290,7 +291,8 @@
         displayField: field,
         originalValue: field === 'deliveryDate'
           ? formatDateToDisplay(tasks[displayIdx][field])
-          : tasks[displayIdx][field]
+          : tasks[displayIdx][field],
+        originalRaw: tasks[displayIdx][field]
       };
 
       renderTable();
@@ -310,6 +312,8 @@
 
     function commitEdit() {
       if (!editing) return;
+      const task = tasks[editing.displayIdx];
+      window.logTaskChange?.(task, editing.displayField, editing.originalRaw, task[editing.displayField]);
       saveTasks();
       editing = null;
       renderTable();

--- a/index.html
+++ b/index.html
@@ -275,6 +275,7 @@
 
   <script src="./month-modal.js"></script>
   <script src="./app-menu.js"></script>
+  <script src="./task-log.js"></script>
   <script src="./settings-modal.js"></script>
   <script src="./legend-renderer.js"></script>
   <script>

--- a/settings-modal.js
+++ b/settings-modal.js
@@ -275,19 +275,25 @@ const SettingsModal = {
               <label for="taskIdOpus${i}" class="text-xs text-gray-400 dark:text-white/60 font-medium block mb-1">ID</label>
               <input id="taskIdOpus${i}" type="text" value="${t.idOpus || ''}" placeholder="Opus ID"
                 class="w-full bg-black/5 dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-300 dark:placeholder-white/20 focus:outline-none focus:border-gray-400 dark:focus:border-white/30 transition-colors"
-                oninput="window._settingsModalUpdateTaskIdOpus(${i}, this.value)">
+                onfocus="window._settingsModalFocusField(${i}, 'idOpus')"
+                oninput="window._settingsModalUpdateTaskIdOpus(${i}, this.value)"
+                onblur="window._settingsModalBlurField(${i}, 'idOpus')">
             </div>
             <div class="col-span-2">
               <label for="taskName${i}" class="text-xs text-gray-400 dark:text-white/60 font-medium block mb-1">Task</label>
               <input id="taskName${i}" type="text" value="${t.name}" maxlength="20" placeholder="Task name"
                 class="w-full bg-black/5 dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-300 dark:placeholder-white/20 focus:outline-none focus:border-gray-400 dark:focus:border-white/30 transition-colors"
-                oninput="window._settingsModalUpdateTaskName(${i}, this.value)">
+                onfocus="window._settingsModalFocusField(${i}, 'name')"
+                oninput="window._settingsModalUpdateTaskName(${i}, this.value)"
+                onblur="window._settingsModalBlurField(${i}, 'name')">
             </div>
             <div class="col-span-2">
               <label for="taskJira${i}" class="text-xs text-gray-400 dark:text-white/60 font-medium block mb-1">Jira Link</label>
               <input id="taskJira${i}" type="url" value="${t.jiraLink || ''}" maxlength="256" placeholder="https://..."
                 class="w-full bg-black/5 dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-300 dark:placeholder-white/20 focus:outline-none focus:border-gray-400 dark:focus:border-white/30 transition-colors"
-                oninput="window._settingsModalUpdateTaskJiraLink(${i}, this.value)">
+                onfocus="window._settingsModalFocusField(${i}, 'jiraLink')"
+                oninput="window._settingsModalUpdateTaskJiraLink(${i}, this.value)"
+                onblur="window._settingsModalBlurField(${i}, 'jiraLink')">
             </div>
           </div>
 
@@ -688,10 +694,29 @@ window._settingsModalUpdateTaskName = (i, v) => {
   }
 };
 
+let _fieldFocusValue = null;
+
+window._settingsModalFocusField = (i, field) => {
+  const tasks = SettingsModal.config.getTasks();
+  if (tasks[i]) {
+    _fieldFocusValue = tasks[i][field];
+  }
+};
+
+window._settingsModalBlurField = (i, field) => {
+  const tasks = SettingsModal.config.getTasks();
+  if (tasks[i]) {
+    window.logTaskChange?.(tasks[i], field, _fieldFocusValue, tasks[i][field]);
+  }
+  _fieldFocusValue = null;
+};
+
 window._settingsModalUpdateTaskColor = (i, c) => {
   const tasks = SettingsModal.config.getTasks();
   if (tasks[i]) {
+    const oldColor = tasks[i].color;
     tasks[i].color = c;
+    window.logTaskChange?.(tasks[i], 'color', oldColor, c);
     SettingsModal.config.onSave?.();
 
     // Update only the color swatch active state for this specific task
@@ -750,6 +775,7 @@ window._settingsModalFinalizeEstimateChange = (i, v) => {
       tasks[i].estimateHistory.push({ date: dateStr, from: oldVal, to: newVal });
     }
   }
+  window.logTaskChange?.(tasks[i], 'estimate', oldVal, newVal);
   _estimateFocusValue = null;
   SettingsModal.config.onSave?.();
 };
@@ -757,6 +783,7 @@ window._settingsModalFinalizeEstimateChange = (i, v) => {
 window._settingsModalUpdateTaskDeliveryDate = (i, v) => {
   const tasks = SettingsModal.config.getTasks();
   if (tasks[i]) {
+    const oldDeliveryDate = tasks[i].deliveryDate;
     // Handle both YYYY-MM-DD (from native date input) and DD/MM/YYYY (from text input) formats
     if (v && v.length === 10) {
       if (v.includes('/')) {
@@ -772,6 +799,7 @@ window._settingsModalUpdateTaskDeliveryDate = (i, v) => {
     } else {
       tasks[i].deliveryDate = '';
     }
+    window.logTaskChange?.(tasks[i], 'deliveryDate', oldDeliveryDate, tasks[i].deliveryDate);
     SettingsModal.config.onSave?.();
   }
 };
@@ -815,7 +843,9 @@ window._settingsModalUpdateMaxCap = (v) => {
 window._settingsModalUpdateTaskStatus = (i, v) => {
   const tasks = SettingsModal.config.getTasks();
   if (tasks[i]) {
+    const oldStatus = tasks[i].status;
     tasks[i].status = v;
+    window.logTaskChange?.(tasks[i], 'status', oldStatus, v);
     SettingsModal.config.onSave?.();
   }
 };

--- a/task-log.js
+++ b/task-log.js
@@ -1,0 +1,69 @@
+// Shared task change-log utilities (localStorage-backed, key: dt_taskLog)
+
+const FIELD_LABELS = {
+  idOpus: 'ID',
+  name: 'Task name',
+  jiraLink: 'Jira link',
+  estimate: 'Estimate',
+  deliveryDate: 'Delivery date',
+  status: 'Status',
+  color: 'Color'
+};
+
+const STATUS_LABELS = {
+  soon: 'Soon',
+  inPause: 'In Pause',
+  inProgress: 'In Progress',
+  devStarted: 'Dev started',
+  checking: 'Final review',
+  done: 'Done',
+  archived: 'Archived'
+};
+
+function taskLogGenerateUid() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+  return `uid-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function taskLogEnsureUid(task) {
+  if (!task.uid) task.uid = taskLogGenerateUid();
+  return task.uid;
+}
+
+function taskLogGetAll() {
+  try {
+    return JSON.parse(localStorage.getItem('dt_taskLog') || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function taskLogSaveAll(entries) {
+  localStorage.setItem('dt_taskLog', JSON.stringify(entries));
+}
+
+function logTaskChange(task, field, from, to) {
+  if (!task) return;
+  const fromStr = String(from ?? '');
+  const toStr = String(to ?? '');
+  if (fromStr === toStr) return;
+
+  taskLogEnsureUid(task);
+  const entries = taskLogGetAll();
+  entries.push({
+    uid: task.uid,
+    field,
+    from: from ?? '',
+    to: to ?? '',
+    date: new Date().toISOString()
+  });
+  if (entries.length > 500) entries.splice(0, entries.length - 500);
+  taskLogSaveAll(entries);
+}
+
+window.FIELD_LABELS = FIELD_LABELS;
+window.STATUS_LABELS = STATUS_LABELS;
+window.taskLogEnsureUid = taskLogEnsureUid;
+window.taskLogGetAll = taskLogGetAll;
+window.taskLogSaveAll = taskLogSaveAll;
+window.logTaskChange = logTaskChange;


### PR DESCRIPTION
## Task change log with vertical timeline

### Summary
- Every change to a task's `status`, `color`, `estimate`, `deliveryDate`, `idOpus`, `name`, and `jiraLink` — made from either the Settings modal or the archive page's inline-edit table — is now recorded in a new `dt_taskLog` localStorage key, keyed by a stable per-task `uid` assigned on first edit.
- Adds a "Change log" card to the left of the Year Heatmap on the Analytics → By-Task tab, rendering the recorded changes as a vertical timeline (newest first), with friendly status labels instead of raw enum values.
- Keystroke-driven fields (`idOpus`, `name`, `jiraLink`) log once per edit (on blur) rather than once per character, matching the existing pattern used for `estimate`.
- The timeline's line/dot/spacing is built with inline styles rather than Tailwind utility classes, since the vendored Tailwind build is pre-compiled/purged and doesn't include several of the classes a Flowbite-style timeline needs (`ms-4`, `mb-10`, `border-s`, arbitrary `-start-*` offsets, etc.); rebuilding it requires `npx @tailwindcss/cli`, which isn't available in this environment.
- Task creation/deletion are intentionally not logged — only field-level changes, per the original request.

### Test plan
- [ ] Open Settings (index.html or analytics.html), change a task's status, estimate, delivery date, name, Jira link, ID, and color one at a time — confirm no console errors.
- [ ] Open archive.html, edit the same fields via the inline table — confirm no console errors.
- [ ] Open analytics.html → By-Task tab, select an edited task, confirm the "Change log" card shows entries newest-first with correct field labels and friendly status text.
- [ ] Edit the same task from both the Settings modal and archive.html — confirm both sets of changes appear in one shared timeline (same `uid`).
- [ ] Switch tasks via the legend chips — confirm the timeline updates to show only that task's entries.
- [ ] Toggle dark/light mode — confirm the timeline (line, dot ring, text colors) matches the rest of the app in both themes.
- [ ] Inspect `localStorage.dt_taskLog` in devtools — confirm entries have `uid`/`field`/`from`/`to`/`date` and the array is capped at 500.

### Files changed
- **New** [task-log.js](task-log.js) (69 lines) — shared `logTaskChange`/`taskLogGetAll`/`taskLogEnsureUid` utilities, `FIELD_LABELS`, `STATUS_LABELS`.
- [settings-modal.js](settings-modal.js) — logging hooks added to the `status`, `color`, `estimate`, `deliveryDate` mutators; new `_settingsModalFocusField`/`_settingsModalBlurField` pair and `onfocus`/`onblur` attributes for `idOpus`/`name`/`jiraLink` inputs.
- [archive.html](archive.html) — `handleCellClick` now stashes the raw pre-edit value; `commitEdit` logs the change before saving.
- [analytics.html](analytics.html) — new `renderTaskLogTimeline(taskIndex)` function; new "Change log" card (`#bytaskLogCard`) added to the By-Task tab grid, alongside the Year Heatmap card (both `md:col-span-6`); wired into `renderByTaskView`.
- [index.html](index.html), [archive.html](archive.html), [analytics.html](analytics.html) — added `<script src="./task-log.js"></script>` before `settings-modal.js`.

### Version info
- **Type:** Feature addition
- **Breaking changes:** None — purely additive; existing task objects gain an optional `uid` field lazily on first edit, no migration needed.
